### PR TITLE
Fix method name typo in EventHandlers.java

### DIFF
--- a/src/main/java/com/zack6849/superlogger/EventsHandler.java
+++ b/src/main/java/com/zack6849/superlogger/EventsHandler.java
@@ -187,7 +187,7 @@ public class EventsHandler implements Listener {
     }
     
     @EventHandler
-    public void onDisalow(PlayerLoginEvent e) {
+    public void onDisallow(PlayerLoginEvent e) {
         if (LOG_DISALLOWED_CONNECTIONS) {
             if (!e.getResult().equals(PlayerLoginEvent.Result.ALLOWED)) {
                 if (e.getResult().equals(PlayerLoginEvent.Result.KICK_BANNED)) {


### PR DESCRIPTION
**PR Breakdown:**
This PR fixes a typo in the name of an event handler. Its current name is `onDisalow` while it should actually be `onDisallow`. This PR addresses this severe flaw in the plugin.

**Justification:**
Typos look unprofessional and must be defeated. Also, with this project being open-source, it could lead to beginners learning wrong ways of spelling 'disallow'.

Thank you!
